### PR TITLE
Update serde to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/vvuk/dwrote-rs"
 license = "MPL-2.0"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 build = "build.rs"
 
@@ -21,10 +21,10 @@ lazy_static = "0.2"
 winapi = "0.2"
 kernel32-sys = "0.2"
 gdi32-sys = "0.2"
-serde = "0.8"
-serde_derive = {version = "0.8", optional = true}
+serde = "0.9"
+serde_derive = {version = "0.9", optional = true}
 
 [build-dependencies.serde_codegen]
-version = "0.8"
+version = "0.9"
 default_features = false
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![cfg_attr(feature = "serde_derive", feature(proc_macro, rustc_attrs, structural_match))]
 #![allow(non_upper_case_globals)]
 
 #[cfg(feature = "serde_derive")]


### PR DESCRIPTION
Procedural macros will be stable in 2 weeks. If you don't want us to rely on serde_derive unconditionally, I can also implement the traits by hand, there are very few of them, and no type is a complex enum.